### PR TITLE
Adds RV screencapture event triggering.

### DIFF
--- a/python/tk_rv_shotgunreview/details_panel_widget.py
+++ b/python/tk_rv_shotgunreview/details_panel_widget.py
@@ -135,7 +135,7 @@ class DetailsPanelWidget(QtGui.QWidget):
 
         # We need to register our screen-grab callback. Instead
         # of what ships with the widget
-        screen_grab.override_screen_grab_callback(self._trigger_rv_screen_grab)
+        screen_grab.ScreenGrabber.SCREEN_GRAB_CALLBACK = self._trigger_rv_screen_grab
 
         # For the basic info widget in the Notes stream we won't show
         # labels for the fields that are persistent. The non-standard,


### PR DESCRIPTION
Makes use of the ability to override the screencapture behavior of the screengrab component of tk-framework-qtwidgets and now triggers an RV event so that the Mode can handle the screengrab. A method is provided for the Mode to then attach the result to the note being created.
