### PR TITLE
For #40130: Maintains the given order at launch of Version entities in the tray.

### DIFF
--- a/python/tk_rv_shotgunreview/tray_model.py
+++ b/python/tk_rv_shotgunreview/tray_model.py
@@ -1,6 +1,13 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
 
-
-# import the shotgun_model module from the shotgun utils framework
 import tank
 from PySide import QtCore, QtGui
 
@@ -45,6 +52,25 @@ class TrayModel(ShotgunModel):
         self._PINNED_THUMBNAIL = QtCore.Qt.UserRole + 1704
 
         self._pinned_items = {}
+        self._version_order = []
+
+    @property
+    def version_order(self):
+        """
+        Used to store a list of version ids in the order that the Versions
+        should be presented in the tray. This property is only used when
+        Version entities are loaded into SG Review directly -- if cuts or
+        playlists are loaded up, the orders defined in those entities are
+        used instead.
+
+        :returns: A list of integer Version entity ids.
+        :rtype: list
+        """
+        return self._version_order
+
+    @version_order.setter
+    def version_order(self, version_ids):
+        self._version_order = version_ids
 
     def clear_pinned_items(self):
         self._pinned_items = {}        

--- a/python/tk_rv_shotgunreview/tray_sort_filter.py
+++ b/python/tk_rv_shotgunreview/tray_sort_filter.py
@@ -1,15 +1,23 @@
-# import the shotgun_model module from the shotgun utils framework
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
 import tank
 from tank.platform.qt import QtCore, QtGui
 
 shotgun_model = tank.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 
 class TraySortFilter(QtGui.QSortFilterProxyModel):
-   
     def lessThan(self, left, right):
-
         sg_left = shotgun_model.get_sg_data(left)
         sg_right = shotgun_model.get_sg_data(right)
+
         if 'cut_order' in sg_left and 'cut_order' in sg_right:
             return sg_left['cut_order'] < sg_right['cut_order']
         elif 'playlists.PlaylistVersionConnection.sg_sort_order' in sg_left and 'playlists.PlaylistVersionConnection.sg_sort_order' in sg_right:
@@ -17,8 +25,24 @@ class TraySortFilter(QtGui.QSortFilterProxyModel):
                         return sg_left['playlists.PlaylistVersionConnection.id'] < sg_right['playlists.PlaylistVersionConnection.id']
                         
                 return sg_left['playlists.PlaylistVersionConnection.sg_sort_order'] < sg_right['playlists.PlaylistVersionConnection.sg_sort_order']
+        elif sg_left.get("type") == "Version" and sg_right.get("type") == "Version":
+            # If we're dealing with Version entities, then we will make use
+            # of the version_order property of our sourceModel. That gets
+            # set by the rv_activity_mode when Version entities are being
+            # loaded into the tray, and represents the order of the Versions
+            # exactly as they were given to RV on launch.
+            model = self.sourceModel()
+            order = model.version_order
+            left_id = sg_left.get("id")
+            right_id = sg_right.get("id")
+
+            if left_id in order and right_id in order:
+                return order.index(left_id) < order.index(right_id)
+            else:
+                # Maintain order if we don't know enough to change it.
+                return True
         else:
-            return 1
+            return True
 
 
     # JS for playlist sorting 


### PR DESCRIPTION
We can't trust the order of items in the tray model at the time that the sort_filter model is asked to sort the items, so we store the list of Version entity ids, as given at launch, on the tray model and reference that from the sort_filter proxy model when needed.