### PR TITLE
For #44088: SG Review: even when loading mini-cut, RV loads media for…

### DIFF
--- a/python/tk_rv_shotgunreview/rv_activity_mode.py
+++ b/python/tk_rv_shotgunreview/rv_activity_mode.py
@@ -1723,8 +1723,7 @@ class RvActivityMode(rvt.MinorMode):
         shadow_inputs = getStringProp(seq_node + ".shadow_edl.inputs", [])
 
         # all shadow_inputs will be used, so de-proxify any proxy sources
-        for i in range(len(shadow_inputs)):
-            shadow_inputs[i] = self.unproxied_source_group(shadow_inputs[i])
+        shadow_inputs = map(self.unproxied_source_group, shadow_inputs)
 
         setProp(seq_node + ".shadow_edl.inputs", shadow_inputs)
 
@@ -2003,11 +2002,13 @@ class RvActivityMode(rvt.MinorMode):
         if (source_name.isdigit()):
             id = int(source_name)
             source_name = self.find_group_from_version_id(id)
-            if (not source_name and id in self.proxy_sources):
-                source_name = self.source_group_from_version_data(self.proxy_sources[id])
-                del self.proxy_sources[id]
-            else :
-                self._app.engine.log_error("Proxy Version '%s' not in proxy map!" % source_name)
+            if (not source_name):
+                try:
+                    source_name = self.source_group_from_version_data(self.proxy_sources[id])
+                    del self.proxy_sources[id]
+                except KeyError:
+                    self._app.engine.log_error("Proxy Version '%d' not in proxy map!" % id)
+                    source_name = str(id)
 
         return source_name
 
@@ -2574,8 +2575,7 @@ class RvActivityMode(rvt.MinorMode):
             setProp(seq_node + ".edl.out",    edl_outs)
 
             # we are using all shadow inputs, so de-proxify any proxy sources
-            for i in range(len(seq_inputs)):
-                seq_inputs[i] = self.unproxied_source_group(seq_inputs[i])
+            seq_inputs = map(self.unproxied_source_group, seq_inputs)
 
             setProp(seq_node + ".shadow_edl.inputs", seq_inputs)
 


### PR DESCRIPTION
… entire cut

  * During sequence creation, delay source creation by creating "proxy
    sources" - a map of the required version_data objects indexed by the
    Version entity ID.  The version ID stands in for the source group
    name while it is a "proxy".   If we are starting in "mini-cut" mode,
    create ("de-proxy") only those sources that are required for that
    view.

  * If we start in minicut view, create remaining sources later only if
    the user activates "entire cut" mode.

  * Modify version_data_from_source() so that it works on proxy sources
    as well as "real" ones.

  * Above means that the "shadow inputs" property of the Sequence may
    contain a mix of "real" and "proxy" source group names, so all
    processing of the shadow inputs is updated to account for that
    possibility.

Shotgun Ticket [**here**](https://internal.shotgunstudio.com/detail/Ticket/44088)

To test:
- Swap into installed RV 7.2.0 here: `/RV64.app/Contents/src/python/sgtk/bundle_cache/manual/tk-rv-shotgunreview//v1.0.42//python/tk_rv_shotgunreview/rv_activity_mode.py`
- Run this command line: `/Applications/RV64.app/Contents/MacOS/RV64 -sendEvent 'gma-play-entity' '{"protocol_version":1,"server":"https://adskdemo.shotgunstudio.com","type":"Version","ids":[7086]}'
`
- Confirm (Session Manager) that only 4 sources are created when we enter cut mode (for the minicut) and the remaining 2 sources are created when we switch to "entire cut".