### PR TITLE
SG Review bug fixes backport from RV-baked version of Toolkit

### DIFF
--- a/python/tk_rv_shotgunreview/popup_utils.py
+++ b/python/tk_rv_shotgunreview/popup_utils.py
@@ -101,6 +101,19 @@ class PopupUtils(QtCore.QObject):
 
         self._filtered_versions_model.data_refreshed.connect(self.filter_tray)
 
+    def destroy(self):
+        if self._filtered_versions_model:
+            self._filtered_versions_model.destroy()
+            self._filtered_versions_model=None
+        if self._rel_shots_model:
+            self._rel_shots_model.destroy()
+            self._rel_shots_model=None
+        if self._rel_cuts_model:
+            self._rel_cuts_model.destroy()
+            self._rel_cuts_model=None
+        if self._steps_model:
+            self._steps_model.destroy()
+            self._steps_model=None
     # related cuts menu menthods
 
     # def mark_pipeline_selections(self):

--- a/python/tk_rv_shotgunreview/tray_main_frame.py
+++ b/python/tk_rv_shotgunreview/tray_main_frame.py
@@ -38,6 +38,10 @@ class TrayMainFrame(QtGui.QFrame):
         # set up the UI
         self.init_ui()
 
+    def destroy(self):
+        if self.tray_model:
+            self.tray_model.destroy()
+            self.tray_model=None
     def show_steps_and_statuses(self, visible):
         self.pipeline_filter_button.setVisible( visible )
         self.status_filter_button.setVisible( visible )


### PR DESCRIPTION
A couple bug fixes! Details below:

**Problem:**
After performing the "SG Review/Initialize Shotgun", a seg fault was triggered when exiting the app (both on linux and macOS).

**Solution:**
This issue was identified by the shotgun toolkit team.
Added a destroy() method to rv_activity_stream in order to be able to call the shotgun toolkit method destroy on both self._cuts_model and self._shot_model.

For reference:
src/python/sgtk/bundle_cache/manual/tk-framework-shotgunutils/v1.2.0/python/shotgun_model/shotgun_query_model.py
"note! We are re-implementing this explicitly because the default implementation results in memory issues - similar to reset(),
scenarios where objects are constructed in python (e.g. QStandardItems) and then handed over to a model and then
subsequently cleared and deallocated by Qt itself (on the C++ side) often results in dangling pointers across the pyside/Qt
boundary, ultimately resulting in crashes or instability.""

Affected files:
src/plugins/rv-packages/sgtk/bundle_cache/manual/tk-rv-shotgunreview/TOOLKIT_VERSION/app.py
src/plugins/rv-packages/sgtk/bundle_cache/manual/tk-rv-shotgunreview/TOOLKIT_VERSION/python/tk_rv_shotgunreview/rv_activity_mode.py

**Problem:** RV-7.QT5: Fix crash when relaunching screening_room

**Solution:** The fatal assert occured in the chromium code of the QtWebEngineCore.
More specifically in the ClientSocketPoolBaseHelper destructor :
  DCHECK(group_map_.empty());

For some reason the source of the issue was to set one time too many the user agent on the QWebEngineProfile: QWebEngineProfile::setHttpUserAgent().
An issue that this investigation uncovered: every time we were  launching the browser, the "( RV )" string kept being re-added to the user agent.
By doing it only once this solved the crash in chromium.
Note that the issue was related to an intercom web socket that remained opened: group_name=ssl/nexus-websocket-a.intercom.io:443
This is why this issue was not reproducible with a shotgun local install.
So Chromium must not allow to change the user agent while there are open sockets.

Also in this changelist, the "--disable-web-security" Qt option was removed as it is no longer necessary to remove it.

Also in this changelist, some additional cleanup of the shotgun toolkit objects.

**Problem:** PySide2 has introduced a "long" type variable in a few places, which has unfortunately broken SG Review when setting attributes or during string replacement.

**Solution:** Added support for long type when setting attributes in RV and for string replacement.