### PR TITLE
SG-19307 Fix for RV crashing on exit when sgtk package was loaded

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,7 @@ class RVShotgunReviewApp(Application):
         """
         if six.PY3:
             return
-        self._rv_activity_stream.deactivate()
+        self._rv_activity_stream.destroy()
 
     #####################################################################################
     # Properties


### PR DESCRIPTION
The problem was that because we were not passing a background task manager to the shotgun models [here](https://github.com/shotgunsoftware/tk-rv-shotgunreview/blob/4c926459e740cc0edb2757cdd3be09a015c6a907/python/tk_rv_shotgunreview/rv_activity_mode.py#L975-L976), they were creating their own. The code is actually written so that it would clean up after itself correctly by calling destroy on the models [here](https://github.com/shotgunsoftware/tk-rv-shotgunreview/blob/4c926459e740cc0edb2757cdd3be09a015c6a907/python/tk_rv_shotgunreview/rv_activity_mode.py#L1090-L1095) as log as we call the `destroy` method. But instead of calling `destroy` we were calling `deactivate` which did not initiate the shut down correctly. 